### PR TITLE
Back up path resolution to fix pnpm

### DIFF
--- a/packages/util/src/util.ts
+++ b/packages/util/src/util.ts
@@ -8,11 +8,16 @@ export function getHash(source: string) {
 
 export function resolvePath(relativePath: string, message?: string) {
   try {
-    const resolvedConfigPath = path.resolve(
+    let resolvedConfigPath = path.resolve(
       __dirname,
       '../../../../',
       relativePath
     )
+    
+    if ( resolvedConfigPath.indexOf( 'node_modules' ) ) {
+        resolvedConfigPath = path_1.default.resolve( process.cwd(), relativePath )
+    }
+    
     fs.accessSync(resolvedConfigPath)
     return resolvedConfigPath
   } catch (err) {


### PR DESCRIPTION
because path isn't always 4 deep (and often isn't).  So let's use cwd as a backup if we're still in node_modules